### PR TITLE
use zerossl acme provider

### DIFF
--- a/docker/caddy/config/Caddyfile
+++ b/docker/caddy/config/Caddyfile
@@ -1,3 +1,8 @@
+{
+  acme_ca https://acme.zerossl.com/v2/DV90
+  email   quadratic@#HOST#
+}
+
 #HOST# {
   reverse_proxy http://host.docker.internal:3000
 }


### PR DESCRIPTION
each self hosted instance requires 7 ssl certificates, letsencrypt has a rate limit of 50 per 7 days...
zerossl offers unlimited free acme ssl certificates, ref: https://zerossl.com/features/acme/