### PR TITLE
Vector db and upgrading to 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Once the Quadratic is initialized, a single command is needed to start all of th
 ./start.sh
 ```
 
+## Upgrading
+
+The bundled Postgres was upgraded from 15 to 17 to enable [pgvector](https://github.com/pgvector/pgvector) (required by the Knowledge / memory feature). Existing installs must wipe their Postgres data directory before the first start on the new image — pg17 cannot read pg15's on-disk format. Run:
+
+```shell
+./stop.sh
+rm -rf ./docker/postgres/data
+./start.sh
+```
+
+This deletes local Quadratic app data (teams, file metadata, knowledge rows, kratos identities). File blobs in `./docker/file-storage` are unaffected, but their DB references will be gone, so plan for a fresh start or take a `pg_dump` first if you need to migrate data.
+
 ## Stopping
 
 To stop running docker images, simply press `ctrl + c` if running in the foreground.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,10 @@ services:
       - pubsub
 
   postgres:
-    image: postgres:15
+    # pgvector image bundles the `vector` extension required by the Knowledge
+    # migration's `CREATE EXTENSION vector`. It is a drop-in superset of the
+    # official postgres image at the same major version.
+    image: pgvector/pgvector:pg17
     container_name: postgres
     restart: always
     ports:


### PR DESCRIPTION
## Summary

Switch the bundled `postgres` service from `postgres:15` to `pgvector/pgvector:pg17` so the new `add_knowledge` migration on the main repo's `memory` branch (which runs `CREATE EXTENSION vector` and creates a `vector(768)` column with an HNSW index) succeeds when `quadratic-api` boots against self-host.

The `pgvector/pgvector` image is a drop-in superset of the official `postgres` image at the same major version (same data dir layout, just with the `vector` extension preinstalled). Pinning `pg17` matches what the main repo did for dev / CI in [quadratichq/quadratic@c5c852cb](https://github.com/quadratichq/quadratic/commit/c5c852cb) and aligns self-host with prod (already on pg17).

## Why pg17 instead of staying on pg15

`pgvector/pgvector:pg15` exists and would have been a fully in-place swap (no data-dir migration). Chose pg17 because:

- Prod is already on pg17, and prod is the only data that matters.
- Avoids future skew between self-host's bundled DB and the main repo's dev/CI DB.
- Preview / dev self-host data can be wiped without consequence.
- External pg15 self-host users get one documented one-time wipe (see README "Upgrading" section) instead of long-term divergence.

## Changes

- `docker-compose.yml`: main `postgres` service image changed from `postgres:15` to `pgvector/pgvector:pg17`, with a comment explaining why.
- `README.md`: new "Upgrading" section above "Stopping" telling existing pg15 installs to `rm -rf ./docker/postgres/data` before the first start on the new image, since pg17 cannot read pg15's on-disk format.

The `postgres-connection` / `ssh-postgres-connection` services are intentionally left alone — they are connection-feature test sandboxes for user data, not the Quadratic app DB, so they don't need pgvector.

## Test plan

- [ ] Clean install: \`./stop.sh && rm -rf ./docker/postgres/data && ./start.sh\` brings the stack up cleanly.
- [ ] \`docker exec -it postgres psql -U postgres -c \"SELECT * FROM pg_available_extensions WHERE name='vector';\"\` returns a row.
- [ ] \`quadratic-api\` logs show \`Applying migration 20260425070357_add_knowledge\` succeed.
- [ ] \`docker exec -it postgres psql -U postgres -c '\d \"Knowledge\"'\` shows \`embedding | vector(768)\` and the \`Knowledge_embedding_hnsw_idx\` HNSW index.